### PR TITLE
add missing parameter name so that example9-5.c compiles without error

### DIFF
--- a/examples/example9-5.c
+++ b/examples/example9-5.c
@@ -1,8 +1,9 @@
 int f(int, ...);
 
-int f(int, ...)
+int f(int a, ...)
 {
-...}
+/*...*/
+}
 
 int g()
 {


### PR DESCRIPTION
reference:
> 'If the declarator includes a parameter type list, the declaration of each parameter shall include an identifier' 
-- ANSI/ISO 9899-1990/6.7.1 Function definitions