### PR TITLE
add minimal player.h (fixes compiler errors)

### DIFF
--- a/examples/player.h
+++ b/examples/player.h
@@ -1,0 +1,1 @@
+#include "example10-4.c"


### PR DESCRIPTION
The following files #include `player.h`:
> `example10-5.c`, `example10-6.c`, `example10-7.c`, `example10-8.c`


but no `player.h` file is present in the repository. In-fact, the contents of `player.h` are contained in `example10-4.c`.

This fix adds a minimal `player.h` that #includes `example10-4.c` so that '.c' files that #include `player.h` will compile.