### PR TITLE
comment out non-program text so that example9-8.c compiles

### DIFF
--- a/examples/example9-8.c
+++ b/examples/example9-8.c
@@ -13,5 +13,6 @@ main()
 	exit(EXIT_SUCCESS);
 }
 
-/* Result */
+/* Result
  fgetc:Bad file number
+*/


### PR DESCRIPTION
The file example9-8.c contains trailing non-program text. this patch puts the text inside the final comment so that the .c file compiles without error.
