### PR TITLE
fix incorrect `offsetof` usage

### DIFF
--- a/examples/example9-1.c
+++ b/examples/example9-1.c
@@ -9,7 +9,7 @@ main()
 		int a, b, c;
 	} s_tr;
 
-	distance = offsetof(s_tr, c);
+	distance = offsetof(struct x, c);
 	printf("Offset of x.c is %lu bytes\n", (unsigned long)distance);
 
 	exit(EXIT_SUCCESS);


### PR DESCRIPTION
The fix provided here is not the only way to fix the code, but it follows the equivalent example code in "The Annotated ANSI Standard (ANSI/ISO 9899-1990) Annotated by Herbert Schildt".

Since this is also a non-trivial error in the book, I have created an issue on the book repo as well:

https://github.com/wardvanwanrooij/thecbook/issues/10
