### PR TITLE
Make fragment examples compile as stand-alone .c files

### DIFF
--- a/examples/example5-9.c
+++ b/examples/example5-9.c
@@ -1,7 +1,10 @@
 #define ARLEN 10
 
-int ar[ARLEN], *ip;
+main()
+{
+	int ar[ARLEN], *ip;
 
-ip = ar;
-while (ip < &ar[ARLEN])
-	*(ip++) = 0;
+	ip = ar;
+	while (ip < &ar[ARLEN])
+		*(ip++) = 0;
+}

--- a/examples/example7-2.c
+++ b/examples/example7-2.c
@@ -2,6 +2,11 @@
       printf("test failed, line %d file %s\n",\
               __LINE__, __FILE__)
 
- /**/ TEST(a != 23);
+main()
+{
+	int a = 0;
 
- /**/
+	/**/ TEST(a != 23);
+
+	/**/
+}

--- a/examples/example7-3.c
+++ b/examples/example7-3.c
@@ -1,8 +1,11 @@
 #include <limits.h>
 
-#if ULONG_MAX+1 != 0
-printf("Preprocessor: ULONG_MAX+1 != 0\n");
-#endif
+main()
+{
+	#if ULONG_MAX+1 != 0
+	printf("Preprocessor: ULONG_MAX+1 != 0\n");
+	#endif
 
-if (ULONG_MAX + 1 != 0)
-	printf("Runtime: ULONG_MAX+1 != 0\n");
+	if (ULONG_MAX + 1 != 0)
+		printf("Runtime: ULONG_MAX+1 != 0\n");
+}


### PR DESCRIPTION
For examples that are only fragments (i.e. not valid .c files) wrap them in `main(){...}` so that they compile.

I'm not sure whether you want to merge this or not, but I figure if the examples are going to have a .c extension then they should be valid C files.

I guess you could consider naming them `.fragment.c` or something or just ignore this PR.
