### PR TITLE
make example5-17.c compile as a stand-alone .c file

### DIFF
--- a/examples/example5-17.c
+++ b/examples/example5-17.c
@@ -1,7 +1,15 @@
+void f(int a, float b) {}
+void g(int a, float b) {}
+void h(int a, float b) {}
+
 void (*fparr[])(int, float) = {
 	/* initializers */
+	f, g, h, f, g, h
 };
 
-/* then call one */
+main()
+{
+	/* then call one */
 
-fparr[5] (1, 3.4);
+	fparr[5] (1, 3.4);
+}


### PR DESCRIPTION
Another fragment-to-valid-c-code patch: initialize the function pointers array and wrapping the executable statement in `main(){}`.
